### PR TITLE
feat: Dark Mode Support und Überstunden-Cache-Invalidierung

### DIFF
--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -4,6 +4,7 @@ import { ChevronDownIcon, MenuIcon, XIcon } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -128,6 +129,7 @@ export function Navigation({ userEmail, onLogout }: NavigationProps) {
           <div className="flex items-center space-x-4">
             {/* Desktop User Info */}
             <div className="hidden md:flex items-center space-x-3">
+              <ThemeToggle />
               <span className="text-sm text-gray-700 dark:text-gray-300">
                 {userEmail}
               </span>
@@ -229,16 +231,19 @@ export function Navigation({ userEmail, onLogout }: NavigationProps) {
                   <span className="text-sm text-gray-700 dark:text-gray-300">
                     {userEmail}
                   </span>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      onLogout();
-                      setIsMobileMenuOpen(false);
-                    }}
-                  >
-                    Abmelden
-                  </Button>
+                  <div className="flex items-center space-x-2">
+                    <ThemeToggle />
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        onLogout();
+                        setIsMobileMenuOpen(false);
+                      }}
+                    >
+                      Abmelden
+                    </Button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { SessionProvider } from "next-auth/react";
+import { ThemeProvider } from "next-themes";
 import { useState } from "react";
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -20,10 +21,17 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <SessionProvider>
-      <QueryClientProvider client={queryClient}>
-        {children}
-        <ReactQueryDevtools initialIsOpen={false} />
-      </QueryClientProvider>
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="system"
+        enableSystem
+        disableTransitionOnChange
+      >
+        <QueryClientProvider client={queryClient}>
+          {children}
+          <ReactQueryDevtools initialIsOpen={false} />
+        </QueryClientProvider>
+      </ThemeProvider>
     </SessionProvider>
   );
 }

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function ThemeToggle() {
+  const { setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return <Button variant="ghost" size="icon" className="h-9 w-9" />;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-9 w-9">
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Theme umschalten</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="mr-2 h-4 w-4" />
+          <span>Hell</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="mr-2 h-4 w-4" />
+          <span>Dunkel</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor className="mr-2 h-4 w-4" />
+          <span>System</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Zusammenfassung
- ✨ Dark Mode mit automatischem System-Theme-Wechsel implementiert
- 🔄 Überstunden-Cache wird nach Import automatisch invalidiert
- 🎨 Theme-Toggle-Button in Navigation für Desktop und Mobile

## Änderungen

### Dark Mode Support
- `next-themes` Provider in `providers.tsx` integriert
- Neue `ThemeToggle` Komponente mit Hell/Dunkel/System-Optionen
- Integration des Toggle-Buttons in die Navigation (Desktop & Mobile)
- Automatischer Wechsel basierend auf Systemeinstellungen
- CSS-Variablen waren bereits für Dark Mode vorbereitet

### Überstunden-Cache-Invalidierung
- Client-Side Event System (`overtimeEvents`) für OvertimeCard Refresh
- Server-Cache-Invalidierung über POST `/api/statistics/overtime`
- Automatischer Trigger nach erfolgreichem Import in `UploadZone`
- Überstunden-Bilanz wird sofort nach Import aktualisiert

## Testing
- [x] Dark Mode wechselt korrekt zwischen Hell/Dunkel/System
- [x] Theme-Einstellung wird persistiert
- [x] Überstunden werden nach Import aktualisiert
- [x] Keine visuellen Regressions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a theme toggle to the header (desktop and mobile) with Light, Dark, and System options. Theme changes apply instantly and respect system preferences.
  - Enabled app-wide theming support for consistent appearance across pages.
  - Overtime dashboard now refreshes automatically: data updates on load, at regular intervals, and immediately after a successful file upload—ensuring overtime statistics reflect the latest imports without manual refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->